### PR TITLE
fixed typo

### DIFF
--- a/rockchip-burn
+++ b/rockchip-burn
@@ -389,7 +389,7 @@ echo Q
 ) | $TOOL || FAIL "oops"
     ;;
     emmc)
-    CMD $TOOL WL 0 "$IMG" || FIAL "oops"
+    CMD $TOOL WL 0 "$IMG" || FAIL "oops"
     ;;
 esac
 


### PR DESCRIPTION
this typo will result in the program sometimes ending in an undesired manner when an error message should be displayed instead